### PR TITLE
feat: combine Terrain and Hydro into single Hydro basemap

### DIFF
--- a/src/components/Map/ResultsMap.tsx
+++ b/src/components/Map/ResultsMap.tsx
@@ -40,6 +40,8 @@ export function ResultsMap({ layers }: ResultsMapProps) {
     setVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
+  const basemap = BASEMAPS.find((b) => b.key === basemapKey)!;
+
   return (
     <MapContainer
       center={[44.0, -69.0]}
@@ -48,9 +50,20 @@ export function ResultsMap({ layers }: ResultsMapProps) {
     >
       <TileLayer
         key={basemapKey}
-        attribution={BASEMAPS.find((b) => b.key === basemapKey)!.attribution}
-        url={BASEMAPS.find((b) => b.key === basemapKey)!.url}
+        attribution={basemap.attribution}
+        url={basemap.url}
+        maxNativeZoom={basemap.maxNativeZoom}
+        maxZoom={20}
       />
+      {basemap.overlayUrl && (
+        <TileLayer
+          key={`${basemapKey}-overlay`}
+          url={basemap.overlayUrl}
+          maxNativeZoom={basemap.maxNativeZoom}
+          maxZoom={20}
+          opacity={0.7}
+        />
+      )}
 
       <MapCenterController layers={layers} />
 

--- a/src/components/Map/basemaps.ts
+++ b/src/components/Map/basemaps.ts
@@ -3,6 +3,8 @@ export interface BasemapOption {
   label: string;
   url: string;
   attribution: string;
+  maxNativeZoom?: number;
+  overlayUrl?: string;
 }
 
 export const BASEMAPS: BasemapOption[] = [
@@ -33,6 +35,24 @@ export const BASEMAPS: BasemapOption[] = [
     url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
     attribution:
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+  },
+  {
+    key: 'imagery',
+    label: 'Imagery',
+    url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}',
+    attribution:
+      'Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>',
+    maxNativeZoom: 16,
+  },
+  {
+    key: 'hydro',
+    label: 'Hydro',
+    url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/tile/{z}/{y}/{x}',
+    attribution:
+      'Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>',
+    maxNativeZoom: 16,
+    overlayUrl:
+      'https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer/tile/{z}/{y}/{x}',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Removes the separate "Terrain" and "Terrain + Hydro" basemap options
- Adds a new "Hydro" option that stacks the USGS hydro tile layer on top of the shaded relief terrain base using Leaflet's multi-TileLayer support
- Extracts repeated `BASEMAPS.find()` calls into a single `basemap` variable for clarity

## Test plan

- [x] Select "Hydro" — verify both terrain shading and hydrography features are visible
- [x] Confirm all other basemaps (Light, Voyager, OpenStreetMap, Dark, Imagery) still work correctly
- [x] Verify the basemap selector no longer shows "Terrain" or "Terrain + Hydro"