### PR TITLE
feat: Experimental natural-language query bar (MVP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 # URL of the sawgraph-api service (e.g. http://localhost:3001 in dev,
 # https://sawgraph-api.onrender.com in prod).
 VITE_API_BASE_URL=http://localhost:3001
+
+# Anthropic API key for the natural-language query bar.
+# DEMO ONLY — this is exposed in the browser bundle. Route through a
+# serverless proxy before any real deployment.
+VITE_ANTHROPIC_KEY=sk-ant-...

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sawgraph-query-editor",
       "version": "0.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.111.0",
         "@tanstack/react-query": "^5.90.21",
         "canvas-confetti": "^1.9.4",
         "driver.js": "^1.6.0",
@@ -35,6 +36,27 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1528,6 +1550,12 @@
         "win32"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
@@ -2587,6 +2615,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2900,6 +2934,19 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3540,6 +3587,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3600,6 +3657,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.111.0",
     "@tanstack/react-query": "^5.90.21",
     "canvas-confetti": "^1.9.4",
     "driver.js": "^1.6.0",

--- a/src/App.css
+++ b/src/App.css
@@ -317,6 +317,43 @@
   gap: 0.75rem;
 }
 
+.nl-query-bar {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.nl-query-bar input {
+  flex: 1;
+  min-width: 200px;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-primary-200);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.nl-query-bar button {
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-700);
+  color: white;
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+}
+
+.nl-query-bar button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.nl-query-error {
+  flex-basis: 100%;
+  color: var(--color-danger, #c0392b);
+  font-size: var(--text-xs);
+}
+
 .question-preview {
   padding: var(--space-md);
   background: var(--color-primary-100);

--- a/src/components/QueryEditor/NLQueryBar.tsx
+++ b/src/components/QueryEditor/NLQueryBar.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { useQueryStore } from '../../store/queryStore';
+import { useQueryPipeline } from '../../hooks/useQueryPipeline';
+import { nlToQuestion } from '../../engine/nlToQuestion';
+
+export function NLQueryBar() {
+  const setQuestion = useQueryStore((s) => s.setQuestion);
+  const { runPipeline, isRunning } = useQueryPipeline();
+  const [text, setText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Run after setQuestion has landed in the store — runPipeline closes over
+  // the store's question, which is stale in the same tick as setQuestion.
+  const [pendingRun, setPendingRun] = useState(false);
+
+  useEffect(() => {
+    if (!pendingRun) return;
+    setPendingRun(false);
+    runPipeline();
+  }, [pendingRun, runPipeline]);
+
+  async function ask() {
+    if (!text.trim() || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setQuestion(await nlToQuestion(text));
+      setPendingRun(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="nl-query-bar">
+      <input
+        type="text"
+        value={text}
+        placeholder="Ask in plain English, e.g. samples downstream of facilities in Maine"
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && ask()}
+        disabled={loading || isRunning}
+      />
+      <button onClick={ask} disabled={loading || isRunning || !text.trim()}>
+        {loading ? 'Thinking…' : 'Ask'}
+      </button>
+      {error && <span className="nl-query-error">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/QueryEditor/QueryEditorContent.tsx
+++ b/src/components/QueryEditor/QueryEditorContent.tsx
@@ -1,6 +1,7 @@
 import { useQueryStore } from '../../store/queryStore';
 import { DefinedTerm } from '../common/DefinedTerm';
 import { QuestionPreview } from './QuestionPreview';
+import { NLQueryBar } from './NLQueryBar';
 import { EntityBlock } from './EntityBlock';
 import { RelationshipSelector } from './RelationshipSelector';
 
@@ -18,6 +19,8 @@ export function QueryEditorContent() {
 
   return (
     <div className="query-editor">
+      <NLQueryBar />
+
       <QuestionPreview question={question} />
 
       <EntityBlock

--- a/src/engine/nlToQuestion.ts
+++ b/src/engine/nlToQuestion.ts
@@ -1,0 +1,69 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { AnalysisQuestion } from '../types/query';
+
+// ponytail: browser-side key = demo only. Move to a serverless proxy before shipping.
+const client = new Anthropic({
+  apiKey: import.meta.env.VITE_ANTHROPIC_KEY,
+  dangerouslyAllowBrowser: true,
+});
+
+// Structure-only mirror of AnalysisQuestion. Detailed filters (substance/NAICS/
+// county URIs) are intentionally omitted — Claude doesn't know the endpoint
+// vocab, so we let it fill structure and leave filters blank.
+const ENTITY = {
+  type: 'object',
+  required: ['type'],
+  properties: {
+    type: { enum: ['samples', 'facilities', 'waterBodies', 'wells'] },
+    region: {
+      type: 'object',
+      properties: {
+        stateCode: { type: 'string', description: '2-digit state FIPS code, e.g. "23" for Maine' },
+      },
+    },
+  },
+} as const;
+
+const QUESTION_SCHEMA = {
+  type: 'object',
+  required: ['blockA', 'relationship', 'blockC'],
+  properties: {
+    blockA: ENTITY,
+    relationship: {
+      type: 'object',
+      required: ['type'],
+      properties: { type: { enum: ['near', 'downstream', 'upstream', 'within'] } },
+    },
+    blockC: ENTITY,
+  },
+} as const;
+
+const SYSTEM = `You convert a user's plain-English question into a SAWGraph AnalysisQuestion.
+The model has three parts: a target entity (blockA), a spatial/hydrological relationship, and an anchor entity (blockC).
+Phrasing: "A <relationship> B" → blockA = A, blockC = B.
+Relationships: near (proximity), downstream / upstream (water flow), within (containment).
+region.stateCode is a 2-digit US state FIPS code (Maine=23, California=06, etc.).
+Only set fields you are confident about; omit anything uncertain.`;
+
+export async function nlToQuestion(text: string): Promise<AnalysisQuestion> {
+  const res = await client.messages.create({
+    model: 'claude-opus-4-8',
+    max_tokens: 1024,
+    system: SYSTEM,
+    tools: [
+      {
+        name: 'build_question',
+        description: 'Emit the structured analysis question',
+        input_schema: QUESTION_SCHEMA as unknown as Anthropic.Tool.InputSchema,
+      },
+    ],
+    tool_choice: { type: 'tool', name: 'build_question' },
+    messages: [{ role: 'user', content: text }],
+  });
+
+  const tool = res.content.find((b) => b.type === 'tool_use');
+  if (!tool || tool.type !== 'tool_use') {
+    throw new Error('Could not turn that into a question — try rephrasing.');
+  }
+  return tool.input as AnalysisQuestion;
+}


### PR DESCRIPTION
## What

Type a question in plain English (e.g. *"samples downstream of facilities in Maine"*) instead of assembling Block A / relationship / Block C by hand.

The app already funnels everything through one `AnalysisQuestion` struct, so NL support is a single translation step: **text → `AnalysisQuestion` → `setQuestion()` → existing pipeline.** Nothing downstream changes.

## How

- `src/engine/nlToQuestion.ts` — one Claude call with forced tool use; the tool's `input_schema` is a structure-only mirror of `AnalysisQuestion`.
- `src/components/QueryEditor/NLQueryBar.tsx` — input + Ask button; sets the question then runs `useQueryPipeline().runPipeline` (via an effect, since `runPipeline` closes over the store's question).
- Wired into `QueryEditorContent`, minimal CSS, `.env.example` documents `VITE_ANTHROPIC_KEY`.

## Scope (deliberately minimal)

- **Structure only** — entity types, relationship, `region.stateCode`. Detailed filters (substance/NAICS/county URIs) left blank; Claude doesn't know the endpoint vocab.
- **Client-side key** — `dangerouslyAllowBrowser`, demo only. Ships in the bundle. Add a serverless proxy before any real deployment.

## Deferred
- Filter-value resolution against live discovery lists.
- Server-side key proxy.
- Streaming / conversational follow-ups.

## Test
1. Put a real key in `.env.local` (`VITE_ANTHROPIC_KEY`).
2. `npm run dev`, open the editor.
3. "samples downstream of facilities in Maine" → Ask → blocks update (state 23), pipeline runs, map renders.
4. `npm run build` passes.

> **Base:** targets `feat/walkthrough-tour` (this branch descends from it) so the diff is only the NL work. Retarget to `main` once the tour branch merges.